### PR TITLE
Add asynchronous thread block event

### DIFF
--- a/Block/CommentThreadAsyncBlockService.php
+++ b/Block/CommentThreadAsyncBlockService.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CommentBundle\Block;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Comment thread asynchronous creation block service
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class CommentThreadAsyncBlockService extends BaseBlockService
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultSettings($resolver);
+
+        $resolver->setDefaults(array(
+            'id'       => null,
+            'template' => 'SonataCommentBundle:Block:thread_async.html.twig',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        return $this->renderResponse($blockContext->getTemplate(), array(
+            'block'     => $blockContext->getBlock(),
+            'settings'  => $blockContext->getSettings()
+        ), $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $form, BlockInterface $block)
+    {
+        $form->add('settings', 'sonata_type_immutable_array', array(
+            'keys' => array(
+                array('id', 'text'),
+            )
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+
+    }
+}

--- a/Event/CommentThreadAsyncListener.php
+++ b/Event/CommentThreadAsyncListener.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CommentBundle\Event;
+
+use Sonata\BlockBundle\Block\BlockServiceInterface;
+use Sonata\BlockBundle\Model\Block;
+use Sonata\BlockBundle\Event\BlockEvent;
+use Sonata\CommentBundle\Block\CommentThreadAsyncBlockService;
+
+/**
+ * Comment thread asynchronous listener
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class CommentThreadAsyncListener
+{
+    /**
+     * @var CommentThreadAsyncBlockService
+     */
+    protected $blockService;
+
+    /**
+     * Add a comment thread asynchronous block service
+     *
+     * @param CommentThreadAsyncBlockService $blockService
+     */
+    public function setBlockService(CommentThreadAsyncBlockService $blockService)
+    {
+        $this->blockService = $blockService;
+    }
+
+    /**
+     * Add blocks services to event
+     *
+     * @param BlockEvent $event
+     */
+    public function onBlock(BlockEvent $event)
+    {
+        $identifier = $event->getSetting('id', null);
+
+        if ($identifier == null) {
+            return;
+        }
+
+        $block = new Block();
+        $block->setId(uniqid());
+        $block->setSettings($event->getSettings());
+        $block->setType($this->blockService->getName());
+
+        $event->addBlock($block);
+    }
+}

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sonata.comment.block.thread.async.class">Sonata\CommentBundle\Block\CommentThreadAsyncBlockService</parameter>
+    </parameters>
+
+    <services>
+        <service id="sonata.comment.block.thread.async" class="%sonata.comment.block.thread.async.class%">
+            <tag name="sonata.block" />
+
+            <argument>sonata.comment.block.thread.async</argument>
+            <argument type="service" id="templating" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/event.xml
+++ b/Resources/config/event.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="sonata.comment.event.sonata.comment" class="Sonata\CommentBundle\Event\CommentThreadAsyncListener">
+            <tag name="kernel.event_listener" event="sonata.block.event.sonata.comment" method="onBlock"/>
+        </service>
+
+    </services>
+</container>

--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -35,8 +35,15 @@ In order to keep the ``averageNote`` of all threads up-to-date, you can use the 
 Add a new comment thread
 ------------------------
 
-You can add a new comment thread by adding this to your template:
+You can add a new comment thread by adding the following code to your template.
+
+If you are using ``SonataBlockBundle``, the following block event is available:
 
 .. code-block:: jinja
 
-    {% include 'SonataCommentBundle:Thread:async.html.twig' with {'id': 'my-custom-thread'} %}
+    {{ sonata_block_render_event('sonata.comment', {'id': 'my-custom-thread-identifier'}) }}
+
+Else, you can use this Twig include:
+
+.. code-block:: jinja
+    {% include 'SonataCommentBundle:Thread:async.html.twig' with {'id': 'my-custom-thread-identifier'} %}

--- a/Resources/views/Block/thread_async.html.twig
+++ b/Resources/views/Block/thread_async.html.twig
@@ -1,0 +1,1 @@
+{% include 'SonataCommentBundle:Thread:async.html.twig' with {'id': settings.id } %}


### PR DESCRIPTION
I've introduced a new block event to add asynchronous comment thread.

Here is the code to add a new one:

``` jinja
{{ sonata_block_render_event('comment.thread_async', {'id': 'my-custom-thread-identifier'}) }}
```
