### PR TITLE
Add an authorName property to comment model

### DIFF
--- a/Form/CommentType.php
+++ b/Form/CommentType.php
@@ -21,6 +21,13 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 class CommentType extends AbstractType
 {
     /**
+     * Is comment model implementing signed interface?
+     *
+     * @var boolean
+     */
+    protected $isSignedInterface = false;
+
+    /**
      * Configures a Comment form.
      *
      * @param FormBuilderInterface $builder
@@ -28,10 +35,36 @@ class CommentType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        if ($options['add_author']) {
+            $builder->add('authorName', 'text', array('required' => true));
+
+            $this->vars['add_author'] = $options['add_author'];
+        }
+
         $builder
             ->add('website', 'url', array('required' => false))
             ->add('email', 'email', array('required' => false))
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'add_author' => !$this->isSignedInterface
+        ));
+    }
+
+    /**
+     * Sets if comment model is implementing signed interface
+     *
+     * @param boolean $isSignedInterface
+     */
+    public function setIsSignedInterface($isSignedInterface)
+    {
+        $this->isSignedInterface = $isSignedInterface;
     }
 
     /**

--- a/Model/Comment.php
+++ b/Model/Comment.php
@@ -42,6 +42,13 @@ class Comment extends AbstractedComment
     protected $thread;
 
     /**
+     * Comment author name
+     *
+     * @var string
+     */
+    protected $authorName;
+
+    /**
      * Comment author email address
      *
      * @var string
@@ -68,9 +75,29 @@ class Comment extends AbstractedComment
     protected $private;
 
     /**
+     * Sets comment author name
+     *
+     * @param string $authorName
+     */
+    public function setAuthorName($authorName)
+    {
+        $this->authorName = $authorName;
+    }
+
+    /**
+     * Returns comment author name
+     *
+     * @return string
+     */
+    public function getAuthorName()
+    {
+        return $this->authorName;
+    }
+
+    /**
      * Sets comment author email address
      *
-     * @param $email
+     * @param string $email
      */
     public function setEmail($email)
     {
@@ -90,7 +117,7 @@ class Comment extends AbstractedComment
     /**
      * Sets comment author website url
      *
-     * @param $website
+     * @param string $website
      */
     public function setWebsite($website)
     {
@@ -110,7 +137,7 @@ class Comment extends AbstractedComment
     /**
      * Sets comment note
      *
-     * @param $note
+     * @param float $note
      */
     public function setNote($note)
     {
@@ -144,7 +171,7 @@ class Comment extends AbstractedComment
     /**
      * Returns comment state label
      *
-     * @return null
+     * @return integer|null
      */
     public function getStateLabel()
     {

--- a/Resources/config/admin_mongodb.xml
+++ b/Resources/config/admin_mongodb.xml
@@ -12,7 +12,7 @@
         <service id="sonata.comment.admin.comment" class="%sonata.comment.admin.comment.class%">
             <tag name="sonata.admin" manager_type="doctrine_mongodb" group="%sonata.comment.admin.groupname%" show_in_menu="false" show_in_dashboard="false" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument />
-            <argument>%sonata.comment.admin.comment.document%</argument>
+            <argument>%sonata.comment.class.comment.document%</argument>
             <argument>%sonata.comment.admin.comment.controller%</argument>
 
             <call method="setTranslationDomain">
@@ -23,7 +23,7 @@
         <service id="sonata.comment.admin.thread" class="%sonata.comment.admin.thread.class%">
             <tag name="sonata.admin" manager_type="doctrine_mongodb" group="%sonata.comment.admin.groupname%" label="conversation" label_catalogue="SonataCommentBundle" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument />
-            <argument>%sonata.comment.admin.thread.document%</argument>
+            <argument>%sonata.comment.class.thread.document%</argument>
             <argument>%sonata.comment.admin.thread.controller%</argument>
 
             <call method="setTranslationDomain">

--- a/Resources/config/admin_orm.xml
+++ b/Resources/config/admin_orm.xml
@@ -12,7 +12,7 @@
         <service id="sonata.comment.admin.comment" class="%sonata.comment.admin.comment.class%">
             <tag name="sonata.admin" manager_type="orm" group="%sonata.comment.admin.groupname%" show_in_menu="false" show_in_dashboard="false" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument />
-            <argument>%sonata.comment.admin.comment.entity%</argument>
+            <argument>%sonata.comment.class.comment.entity%</argument>
             <argument>%sonata.comment.admin.comment.controller%</argument>
 
             <call method="setTranslationDomain">
@@ -23,7 +23,7 @@
         <service id="sonata.comment.admin.thread" class="%sonata.comment.admin.thread.class%">
             <tag name="sonata.admin" manager_type="orm" group="%sonata.comment.admin.groupname%" label="conversation" label_catalogue="SonataCommentBundle" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument />
-            <argument>%sonata.comment.admin.thread.entity%</argument>
+            <argument>%sonata.comment.class.thread.entity%</argument>
             <argument>%sonata.comment.admin.thread.controller%</argument>
 
             <call method="setTranslationDomain">

--- a/Resources/config/doctrine/BaseComment.mongodb.xml
+++ b/Resources/config/doctrine/BaseComment.mongodb.xml
@@ -6,10 +6,11 @@
 
     <mapped-superclass name="Sonata\CommentBundle\Document\BaseComment">
 
-        <field name="email"   column="email"   type="string"  nullable="true" />
-        <field name="website" column="website" type="string"  nullable="true" />
-        <field name="note"    column="note"    type="float"   nullable="true" />
-        <field name="private" column="private" type="boolean" nullable="true" />
+        <field name="authorName" column="author_name" type="string"  nullable="false" />
+        <field name="email"      column="email"       type="string"  nullable="true" />
+        <field name="website"    column="website"     type="string"  nullable="true" />
+        <field name="note"       column="note"        type="float"   nullable="true" />
+        <field name="private"    column="private"     type="boolean" nullable="true" />
 
     </mapped-superclass>
 

--- a/Resources/config/doctrine/BaseComment.orm.xml
+++ b/Resources/config/doctrine/BaseComment.orm.xml
@@ -6,10 +6,11 @@
 
     <mapped-superclass name="Sonata\CommentBundle\Entity\BaseComment">
 
-        <field name="email"   column="email"   type="string"  nullable="true" />
-        <field name="website" column="website" type="string"  nullable="true" />
-        <field name="note"    column="note"    type="float"   nullable="true" />
-        <field name="private" column="private" type="boolean" nullable="true" />
+        <field name="authorName" column="author_name" type="string"  nullable="false" />
+        <field name="email"      column="email"       type="string"  nullable="true" />
+        <field name="website"    column="website"     type="string"  nullable="true" />
+        <field name="note"       column="note"        type="float"   nullable="true" />
+        <field name="private"    column="private"     type="boolean" nullable="true" />
 
     </mapped-superclass>
 

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -11,12 +11,15 @@
     <services>
         <service id="sonata.comment.form.comment_type" class="Sonata\CommentBundle\Form\CommentType">
             <argument>%fos_comment.model.comment.class%</argument>
+            <call method="setIsSignedInterface">
+                <argument>%sonata.comment.class.comment.signed%</argument>
+            </call>
 
             <tag name="form.type" alias="sonata_comment_comment" />
         </service>
 
         <service id="sonata.comment.form.comment_status_type" class="Sonata\CoreBundle\Form\Type\StatusType">
-            <argument>%sonata.comment.admin.comment.entity%</argument>
+            <argument>%sonata.comment.class.comment.entity%</argument>
             <argument>getStateList</argument>
             <argument>sonata_comment_status</argument>
 

--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -9,6 +9,7 @@ In addition to ``FOSCommentBundle`` entities properties, we have added some prop
 Comment
 ^^^^^^^
 
+    - ``authorName`` property: allows you to specify an author name,
     - ``website`` property: allows you to (optionally) store the author website URL,
     - ``email`` property: allows you to (optionally) store the author email address,
     - ``note`` property: allows you to add a note to your comments,

--- a/Resources/translations/SonataCommentBundle.en.xliff
+++ b/Resources/translations/SonataCommentBundle.en.xliff
@@ -18,6 +18,10 @@
                 <source>form_label_email</source>
                 <target>Your email address</target>
             </trans-unit>
+            <trans-unit id="form_label_author_name">
+                <source>form_label_author_name</source>
+                <target>Your name</target>
+            </trans-unit>
             <trans-unit id="sonata_comment_admin_edit">
                 <source>sonata_comment_admin_edit</source>
                 <target>Edit</target>

--- a/Resources/translations/SonataCommentBundle.fr.xliff
+++ b/Resources/translations/SonataCommentBundle.fr.xliff
@@ -18,6 +18,10 @@
                 <source>form_label_email</source>
                 <target>Votre adresse e-mail</target>
             </trans-unit>
+            <trans-unit id="form_label_author_name">
+                <source>form_label_author_name</source>
+                <target>Votre nom</target>
+            </trans-unit>
             <trans-unit id="sonata_comment_admin_edit">
                 <source>sonata_comment_admin_edit</source>
                 <target>Editer</target>

--- a/Resources/views/Thread/comment_new_content.html.twig
+++ b/Resources/views/Thread/comment_new_content.html.twig
@@ -36,24 +36,27 @@
                     <div class="panel-body">
                         {% block fos_comment_form_fields %}
                             <div class="row">
-                                <div class="col-sm-12">
-                                    <div class="fos_comment_form_errors">
-                                        {{ form_errors(form) }}
-                                        {{ form_errors(form.body) }}
+                                {% if form.authorName is defined %}
+                                    <div class="col-sm-4">
+                                        {{ form_label(form.authorName, 'form_label_author_name'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
+                                        {{ form_widget(form.authorName, {'horizontal_input_wrapper_class': ''}) }}
                                     </div>
+                                {% endif %}
 
-                                    {{ form_label(form.body, 'form_label_body'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
-                                    {{ form_widget(form.body, {'horizontal_input_wrapper_class': ''}) }}
-                                </div>
-
-                                <div class="col-sm-6">
+                                <div class="col-sm-4">
                                     {{ form_label(form.website, 'form_label_website'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
                                     {{ form_widget(form.website, {'horizontal_input_wrapper_class': ''}) }}
                                 </div>
 
-                                <div class="col-sm-6">
+                                <div class="col-sm-4">
                                     {{ form_label(form.email, 'form_label_email'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
                                     {{ form_widget(form.email, {'horizontal_input_wrapper_class': ''}) }}
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    {{ form_label(form.body, 'form_label_body'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
+                                    {{ form_widget(form.body, {'horizontal_input_wrapper_class': ''}) }}
                                 </div>
                             </div>
 

--- a/Tests/Document/BaseCommentTest.php
+++ b/Tests/Document/BaseCommentTest.php
@@ -32,6 +32,8 @@ class BaseCommentTest extends \PHPUnit_Framework_TestCase
         $comment->setWebsite('http://www.example.com');
         $comment->setEmail('test@example.com');
         $comment->setNote(0.20);
+        $comment->setPrivate(true);
+        $comment->setAuthorName('My name');
 
         $date = new \DateTime();
         $comment->setCreatedAt($date);
@@ -40,11 +42,12 @@ class BaseCommentTest extends \PHPUnit_Framework_TestCase
         $comment->setThread($thread);
 
         // Then
-        $this->assertEquals('Anonymous', $comment->getAuthorName(), 'Should return Anonymous as author name');
         $this->assertEquals('Comment text', $comment->getBody(), 'Should return correct comment body');
         $this->assertEquals('http://www.example.com', $comment->getWebsite(), 'Should return correct comment author website');
         $this->assertEquals('test@example.com', $comment->getEmail(), 'Should return correct comment author email address');
         $this->assertEquals(0.20, $comment->getNote(), 'Should return correct comment note');
+        $this->assertTrue($comment->isPrivate(), 'Should return that comment is flagged as private');
+        $this->assertEquals('My name', $comment->getAuthorName(), 'Should return correct comment author name');
         $this->assertEquals($date, $comment->getCreatedAt(), 'Should return correct creation date');
 
         $this->assertEquals($thread, $comment->getThread(), 'Should return correct thread');

--- a/Tests/Entity/BaseCommentTest.php
+++ b/Tests/Entity/BaseCommentTest.php
@@ -33,6 +33,7 @@ class BaseCommentTest extends \PHPUnit_Framework_TestCase
         $comment->setEmail('test@example.com');
         $comment->setNote(0.20);
         $comment->setPrivate(true);
+        $comment->setAuthorName('My name');
 
         $date = new \DateTime();
         $comment->setCreatedAt($date);
@@ -41,12 +42,12 @@ class BaseCommentTest extends \PHPUnit_Framework_TestCase
         $comment->setThread($thread);
 
         // Then
-        $this->assertEquals('Anonymous', $comment->getAuthorName(), 'Should return Anonymous as author name');
         $this->assertEquals('Comment text', $comment->getBody(), 'Should return correct comment body');
         $this->assertEquals('http://www.example.com', $comment->getWebsite(), 'Should return correct comment author website');
         $this->assertEquals('test@example.com', $comment->getEmail(), 'Should return correct comment author email address');
         $this->assertEquals(0.20, $comment->getNote(), 'Should return correct comment note');
         $this->assertTrue($comment->isPrivate(), 'Should return that comment is flagged as private');
+        $this->assertEquals('My name', $comment->getAuthorName(), 'Should return correct comment author name');
         $this->assertEquals($date, $comment->getCreatedAt(), 'Should return correct creation date');
 
         $this->assertEquals($thread, $comment->getThread(), 'Should return correct thread');


### PR DESCRIPTION
I've added a `authorName` property which is added only when `Comment` entity does not implements `FOS\CommentBundle\Model\SignedCommentInterface` which is for use of `FOSUserBundle` and authenticated feature.

Here is the view:
![capture decran 2014-02-13 a 15 38 41](https://f.cloud.github.com/assets/103900/2160718/a07aa298-94bc-11e3-83d7-646998576670.png)
