### PR TITLE
SONATA-464 - Fix for refreshing all comments

### DIFF
--- a/Resources/public/js/comments.js
+++ b/Resources/public/js/comments.js
@@ -136,7 +136,9 @@
                         serializedData,
                         // success
                         function(data, statusCode) {
-                            FOS_COMMENT.appendComment(data, that);
+                            var threadId = FOS_COMMENT.thread_container.attr('data-thread');
+                            FOS_COMMENT.getThreadComments(threadId);
+
                             that.trigger('fos_comment_new_comment', data);
                         },
                         // error


### PR DESCRIPTION
When adding a new comment, all elements including the comments counter will now be refreshed correctly.
