### PR TITLE
Add note field to form type

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -51,6 +51,12 @@ class Configuration implements ConfigurationInterface
                         ->thenInvalid('The manager type %s is not supported. Please choose one of '.json_encode($supportedManagerTypes))
                     ->end()
                 ->end()
+                ->arrayNode('notes')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('values')->defaultValue(array(1, 2, 3, 4 ,5))->end()
+                    ->end()
+                ->end()
 
                 ->arrayNode('class')
                     ->children()

--- a/DependencyInjection/SonataCommentExtension.php
+++ b/DependencyInjection/SonataCommentExtension.php
@@ -42,6 +42,7 @@ class SonataCommentExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('event.xml');
         $loader->load('form.xml');
+        $loader->load('note.xml');
         $loader->load('orm.xml');
         $loader->load('twig.xml');
 
@@ -69,6 +70,7 @@ class SonataCommentExtension extends Extension
         $this->configureTranslationDomain($config, $container);
         $this->configureBlocksEvents($container);
         $this->configureFormTypes($config, $container);
+        $this->configureNotesValues($config, $container);
 
         $isSignedInterface = false;
 
@@ -171,6 +173,18 @@ class SonataCommentExtension extends Extension
         $container
             ->getDefinition('sonata.comment.form.comment_status_type')
             ->replaceArgument(0, $config['class']['comment'])
+        ;
+    }
+
+    /**
+     * @param array            $config    A configuration array
+     * @param ContainerBuilder $container Symfony container builder
+     */
+    public function configureNotesValues(array $config, ContainerBuilder $container)
+    {
+        $container
+            ->getDefinition('sonata.comment.note.provider')
+            ->replaceArgument(1, $config['notes']['values'])
         ;
     }
 

--- a/Form/CommentType.php
+++ b/Form/CommentType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CommentBundle\Form;
 
+use Sonata\CommentBundle\Note\NoteProvider;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -20,6 +21,21 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class CommentType extends AbstractType
 {
+    /**
+     * @var NoteProvider
+     */
+    protected $noteProvider;
+
+    /**
+     * Constructor
+     *
+     * @param NoteProvider $noteProvider
+     */
+    public function __construct(NoteProvider $noteProvider)
+    {
+        $this->noteProvider = $noteProvider;
+    }
+
     /**
      * Is comment model implementing signed interface?
      *
@@ -41,6 +57,13 @@ class CommentType extends AbstractType
             $this->vars['add_author'] = $options['add_author'];
         }
 
+        if ($options['show_note']) {
+            $builder->add('note', 'choice', array(
+                'required' => false,
+                'choices'  => $this->noteProvider->getValues()
+            ));
+        }
+
         $builder
             ->add('website', 'url', array('required' => false))
             ->add('email', 'email', array('required' => false))
@@ -53,7 +76,8 @@ class CommentType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'add_author' => !$this->isSignedInterface
+            'add_author' => !$this->isSignedInterface,
+            'show_note'  => true
         ));
     }
 

--- a/Manager/CommentManager.php
+++ b/Manager/CommentManager.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CommentBundle\Manager;
+
+use Sonata\CommentBundle\Model\Thread;
+
+use FOS\CommentBundle\Entity\CommentManager as BaseCommentManager;
+
+class CommentManager extends BaseCommentManager
+{
+    /**
+     * Returns Thread average note
+     *
+     * @param Thread $thread
+     *
+     * @return float
+     */
+    public function findAverageNote(Thread $thread)
+    {
+        return $this->repository->createQueryBuilder('c')
+            ->select('avg(c.note)')
+            ->where('c.private <> :private')
+            ->andWhere('c.thread = :thread')
+            ->setParameters(array(
+                'private' => 1,
+                'thread'  => $thread
+            ))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/Manager/ThreadManager.php
+++ b/Manager/ThreadManager.php
@@ -12,9 +12,9 @@
 namespace Sonata\CommentBundle\Manager;
 
 use Doctrine\ORM\EntityManager;
+use Sonata\CommentBundle\Model\Thread;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-use FOS\CommentBundle\Entity\CommentManager;
 use FOS\CommentBundle\Entity\ThreadManager as BaseThreadManager;
 
 class ThreadManager extends BaseThreadManager

--- a/Note/NoteProvider.php
+++ b/Note/NoteProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CommentBundle\Note;
+
+use Sonata\CommentBundle\Model\Thread;
+
+use FOS\CommentBundle\Model\CommentManager;
+
+/**
+ * Class NoteProvider
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class NoteProvider
+{
+    /**
+     * @var CommentManager
+     */
+    protected $commentManager;
+
+    /**
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * Constructor
+     *
+     * @param CommentManager $commentManager A comment manager
+     * @param array          $values         An array of notes values
+     */
+    public function __construct(CommentManager $commentManager, array $values) {
+        $this->commentManager = $commentManager;
+        $this->values         = $values;
+    }
+
+    /**
+     * Returns notes values
+     *
+     * @return array
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     * Returns Thread average note
+     *
+     * @param Thread $thread
+     *
+     * @return float
+     */
+    public function findAverageNote(Thread $thread)
+    {
+        return $this->commentManager->findAverageNote($thread);
+    }
+}

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -10,7 +10,8 @@
 
     <services>
         <service id="sonata.comment.form.comment_type" class="Sonata\CommentBundle\Form\CommentType">
-            <argument>%fos_comment.model.comment.class%</argument>
+            <argument type="service" id="sonata.comment.note.provider" />
+
             <call method="setIsSignedInterface">
                 <argument>%sonata.comment.class.comment.signed%</argument>
             </call>

--- a/Resources/config/note.xml
+++ b/Resources/config/note.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sonata.comment.note.provider" class="Sonata\CommentBundle\Note\NoteProvider">
+            <argument type="service" id="sonata.comment.manager.comment" />
+            <argument />
+        </service>
+    </services>
+</container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -6,12 +6,20 @@
 
 
     <parameters>
+        <parameter key="sonata.comment.manager.comment.class">Sonata\CommentBundle\Manager\CommentManager</parameter>
         <parameter key="sonata.comment.manager.thread.class">Sonata\CommentBundle\Manager\ThreadManager</parameter>
     </parameters>
 
     <services>
+        <service id="sonata.comment.manager.comment" class="%sonata.comment.manager.comment.class%">
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="fos_comment.sorting_factory" />
+            <argument type="service" id="fos_comment.entity_manager" />
+            <argument>%fos_comment.model.comment.class%</argument>
+        </service>
+
         <service id="sonata.comment.manager.thread" class="%sonata.comment.manager.thread.class%">
-            <argument type="service" id="fos_comment.manager.comment.default" />
+            <argument type="service" id="sonata.comment.manager.comment" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_comment.entity_manager" />
             <argument>%fos_comment.model.thread.class%</argument>

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -82,6 +82,8 @@ Then add these bundles in the config mapping definition (or enable `auto_mapping
         form:
             comment:
                 type: sonata_comment_comment
+        notes:
+            values: [1, 2, 3] # Optional, default would be: [1, 2, 3, 4, 5]
 
     doctrine:
         orm:

--- a/Resources/translations/SonataCommentBundle.en.xliff
+++ b/Resources/translations/SonataCommentBundle.en.xliff
@@ -18,6 +18,10 @@
                 <source>form_label_email</source>
                 <target>Your email address</target>
             </trans-unit>
+            <trans-unit id="form_label_note">
+                <source>form_label_note</source>
+                <target>Your note</target>
+            </trans-unit>
             <trans-unit id="form_label_author_name">
                 <source>form_label_author_name</source>
                 <target>Your name</target>
@@ -29,6 +33,10 @@
             <trans-unit id="sonata_comment_admin_view_comments">
                 <source>sonata_comment_admin_view_comments</source>
                 <target>View comments</target>
+            </trans-unit>
+            <trans-unit id="sonata_comment_note_given">
+                <source>sonata_comment_note_given</source>
+                <target>Note given: </target>
             </trans-unit>
             <trans-unit id="form.label_id">
                 <source>form.label_id</source>

--- a/Resources/translations/SonataCommentBundle.fr.xliff
+++ b/Resources/translations/SonataCommentBundle.fr.xliff
@@ -18,6 +18,10 @@
                 <source>form_label_email</source>
                 <target>Votre adresse e-mail</target>
             </trans-unit>
+            <trans-unit id="form_label_note">
+                <source>form_label_note</source>
+                <target>Votre note</target>
+            </trans-unit>
             <trans-unit id="form_label_author_name">
                 <source>form_label_author_name</source>
                 <target>Votre nom</target>
@@ -29,6 +33,10 @@
             <trans-unit id="sonata_comment_admin_view_comments">
                 <source>sonata_comment_admin_view_comments</source>
                 <target>Voir les commentaires</target>
+            </trans-unit>
+            <trans-unit id="sonata_comment_note_given">
+                <source>sonata_comment_note_given</source>
+                <target>Note donnée : </target>
             </trans-unit>
             <trans-unit id="form.label_id">
                 <source>form.label_id</source>

--- a/Resources/views/Thread/comment_content.html.twig
+++ b/Resources/views/Thread/comment_content.html.twig
@@ -60,6 +60,10 @@
                 {% if comment is fos_comment_in_state(constant('FOS\\CommentBundle\\Model\\CommentInterface::STATE_DELETED')) %}
                     {% trans from 'FOSCommentBundle' %}fos_comment_comment_deleted{% endtrans %}
                 {% else %}
+                    {% if comment.note %}
+                        <p>{{ 'sonata_comment_note_given'|trans({}, 'SonataCommentBundle') }}{{ comment.note }}</p>
+                    {% endif %}
+
                     {% if comment is fos_comment_raw %}
                         {{ comment.rawBody | raw }}
                     {% else %}

--- a/Resources/views/Thread/comment_new_content.html.twig
+++ b/Resources/views/Thread/comment_new_content.html.twig
@@ -37,20 +37,25 @@
                         {% block fos_comment_form_fields %}
                             <div class="row">
                                 {% if form.authorName is defined %}
-                                    <div class="col-sm-4">
+                                    <div class="col-sm-3">
                                         {{ form_label(form.authorName, 'form_label_author_name'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
                                         {{ form_widget(form.authorName, {'horizontal_input_wrapper_class': ''}) }}
                                     </div>
                                 {% endif %}
 
-                                <div class="col-sm-4">
+                                <div class="col-sm-3">
                                     {{ form_label(form.website, 'form_label_website'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
                                     {{ form_widget(form.website, {'horizontal_input_wrapper_class': ''}) }}
                                 </div>
 
-                                <div class="col-sm-4">
+                                <div class="col-sm-3">
                                     {{ form_label(form.email, 'form_label_email'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
                                     {{ form_widget(form.email, {'horizontal_input_wrapper_class': ''}) }}
+                                </div>
+
+                                <div class="col-sm-3">
+                                    {{ form_label(form.note, 'form_label_note'|trans({}, 'SonataCommentBundle'), {'horizontal_label_class': ''}) }}
+                                    {{ form_widget(form.note, {'horizontal_input_wrapper_class': ''}) }}
                                 </div>
                             </div>
                             <div class="row">

--- a/Tests/Note/NoteProviderTest.php
+++ b/Tests/Note/NoteProviderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CommentBundle\Tests\Note;
+
+use Sonata\CommentBundle\Note\NoteProvider;
+
+/**
+ * This is the NoteProvider test class
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class NoteProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test findAverageNote() method
+     */
+    public function testFindAverageNote()
+    {
+        // Given
+        $thread = $this->getMock('Sonata\CommentBundle\Model\Thread');
+
+        $commentManager = $this->getMockBuilder('Sonata\CommentBundle\Manager\CommentManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $commentManager->expects($this->once())->method('findAverageNote')->will($this->returnValue(3.5));
+
+        $provider = new NoteProvider($commentManager, array(0, 1, 2, 3));
+
+        // When
+        $averageNote = $provider->findAverageNote($thread);
+
+        // Then
+        $this->assertEquals(3.5, $averageNote, 'Note should be the same as comment manager query returns');
+    }
+
+    /**
+     * Test getValues() method
+     */
+    public function testGetValues()
+    {
+        // Given
+        $thread = $this->getMock('Sonata\CommentBundle\Model\Thread');
+
+        $commentManager = $this->getMockBuilder('Sonata\CommentBundle\Manager\CommentManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $provider = new NoteProvider($commentManager, array(1, 2, 3));
+
+        // When
+        $notes = $provider->getValues();
+
+        // Then
+        $this->assertEquals(array(1, 2, 3), $notes, 'Should return notes given in constructor');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,10 @@
         "sonata-project/doctrine-extensions": "~1.0",
         "sonata-project/easy-extends-bundle": "~2.1"
     },
+    "require-dev": {
+        "sonata-project/classification-bundle": "~2.2",
+        "sonata-project/media-bundle": "~2.2"
+    },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "~2.2"
     },


### PR DESCRIPTION
I've added a note field to use the notation feature:

![capture decran 2014-03-05 a 14 00 54](https://f.cloud.github.com/assets/103900/2333190/87988344-a466-11e3-89fd-ca022bf867d3.png)

Note is also visible in admin comments list:

![capture decran 2014-03-05 a 14 04 37](https://f.cloud.github.com/assets/103900/2333199/bd8c39aa-a466-11e3-83ae-8cdd19f06149.png)
