### PR TITLE
Fixed paths related to SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Comment.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Comment.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Application\Sonata\CommentBundle\Document\Comment" table="comment__comment">
+    <entity name="{{ namespace }}\Document\Comment" table="comment__comment">
 
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />

--- a/Resources/config/doctrine/Comment.orm.xml.skeleton
+++ b/Resources/config/doctrine/Comment.orm.xml.skeleton
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Application\Sonata\CommentBundle\Entity\Comment" table="comment__comment">
+    <entity name="{{ namespace }}\Entity\Comment" table="comment__comment">
 
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />

--- a/Resources/config/doctrine/Thread.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Thread.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Application\Sonata\CommentBundle\Document\Thread" table="comment__thread">
+    <entity name="{{ namespace }}\Document\Thread" table="comment__thread">
 
         <id name="id" column="id" type="string" />
 

--- a/Resources/config/doctrine/Thread.orm.xml.skeleton
+++ b/Resources/config/doctrine/Thread.orm.xml.skeleton
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Application\Sonata\CommentBundle\Entity\Thread" table="comment__thread">
+    <entity name="{{ namespace }}\Entity\Thread" table="comment__thread">
 
         <id name="id" column="id" type="string" />
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "friendsofsymfony/comment-bundle": "^2.0",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/doctrine-extensions": "^1.0",
-        "sonata-project/easy-extends-bundle": "^2.1"
+        "sonata-project/easy-extends-bundle": "^2.2"
     },
     "require-dev": {
         "sonata-project/classification-bundle": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "friendsofsymfony/comment-bundle": "^2.0",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/doctrine-extensions": "^1.0",
-        "sonata-project/easy-extends-bundle": "^2.2"
+        "sonata-project/easy-extends-bundle": "^2.1"
     },
     "require-dev": {
         "sonata-project/classification-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardcoded paths, which become invalid after enabling
the '--namespace' option in SonataEasyExtendsBundle's last release
(https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0)

See also: https://github.com/sonata-project/SonataMediaBundle/pull/1250