### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/Admin/Model/CommentAdmin.php
+++ b/Admin/Model/CommentAdmin.php
@@ -15,6 +15,9 @@ use Sonata\AdminBundle\Admin\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\CommentBundle\Form\Type\CommentStatusType;
+use Sonata\CoreBundle\Form\Type\DateTimePickerType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 abstract class CommentAdmin extends Admin
 {
@@ -24,12 +27,16 @@ abstract class CommentAdmin extends Admin
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->add('createdAt', 'sonata_type_datetime_picker')
+            ->add('createdAt', DateTimePickerType::class)
             ->add('body')
             ->add('email')
             ->add('website')
-            ->add('state', 'sonata_comment_status', ['translation_domain' => 'SonataCommentBundle'])
-            ->add('private', 'checkbox', ['required' => false])
+            ->add('state', CommentStatusType::class, [
+                'translation_domain' => 'SonataCommentBundle',
+            ])
+            ->add('private', CheckboxType::class, [
+                'required' => false,
+            ])
         ;
     }
 

--- a/Block/CommentThreadAsyncBlockService.php
+++ b/Block/CommentThreadAsyncBlockService.php
@@ -15,6 +15,8 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -52,9 +54,9 @@ class CommentThreadAsyncBlockService extends BaseBlockService
      */
     public function buildEditForm(FormMapper $form, BlockInterface $block)
     {
-        $form->add('settings', 'sonata_type_immutable_array', [
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['id', 'text'],
+                ['id', TextType::class],
             ],
         ]);
     }

--- a/Form/Type/CommentType.php
+++ b/Form/Type/CommentType.php
@@ -11,8 +11,13 @@
 
 namespace Sonata\CommentBundle\Form\Type;
 
+use FOS\CommentBundle\Form\CommentType as FOSCommentType;
 use Sonata\CommentBundle\Note\NoteProvider;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -52,21 +57,21 @@ class CommentType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['add_author']) {
-            $builder->add('authorName', 'text', ['required' => true]);
+            $builder->add('authorName', TextType::class, ['required' => true]);
 
             $this->vars['add_author'] = $options['add_author'];
         }
 
         if ($options['show_note']) {
-            $builder->add('note', 'choice', [
+            $builder->add('note', ChoiceType::class, [
                 'required' => false,
                 'choices' => $this->noteProvider->getValues(),
             ]);
         }
 
         $builder
-            ->add('website', 'url', ['required' => false])
-            ->add('email', 'email', ['required' => false])
+            ->add('website', UrlType::class, ['required' => false])
+            ->add('email', EmailType::class, ['required' => false])
         ;
     }
 
@@ -112,6 +117,6 @@ class CommentType extends AbstractType
      */
     public function getParent()
     {
-        return 'fos_comment_comment';
+        return FOSCommentType::class;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,21 +17,21 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "friendsofsymfony/comment-bundle": "^2.0",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.1",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/form": "^2.3 || ^3.0",
-        "symfony/http-foundation": "^2.3 || ^3.0",
-        "symfony/security": "^2.3 || ^3.0"
+        "symfony/console": "^2.8 || ^3.2",
+        "symfony/form": "^2.8 || ^3.2",
+        "symfony/http-foundation": "^2.8 || ^3.2",
+        "symfony/security": "^2.8 || ^3.2"
     },
     "require-dev": {
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/classification-bundle": "^3.0",
         "sonata-project/media-bundle": "^3.6",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "For doctrine ORM admin integration"


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
