### PR TITLE
Drop PHPUnit 4

### DIFF
--- a/Tests/Document/BaseCommentTest.php
+++ b/Tests/Document/BaseCommentTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CommentBundle\Tests\Document;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CommentBundle\Document\BaseComment;
 use Sonata\CommentBundle\Document\BaseThread;
 
@@ -19,7 +20,7 @@ use Sonata\CommentBundle\Document\BaseThread;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class BaseCommentTest extends \PHPUnit_Framework_TestCase
+class BaseCommentTest extends TestCase
 {
     public function testGetters()
     {

--- a/Tests/Document/BaseThreadTest.php
+++ b/Tests/Document/BaseThreadTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CommentBundle\Tests\Document;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CommentBundle\Document\BaseThread;
 
 /**
@@ -18,7 +19,7 @@ use Sonata\CommentBundle\Document\BaseThread;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class BaseThreadTest extends \PHPUnit_Framework_TestCase
+class BaseThreadTest extends TestCase
 {
     public function testGetters()
     {

--- a/Tests/Entity/BaseCommentTest.php
+++ b/Tests/Entity/BaseCommentTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CommentBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CommentBundle\Entity\BaseComment;
 use Sonata\CommentBundle\Entity\BaseThread;
 
@@ -19,7 +20,7 @@ use Sonata\CommentBundle\Entity\BaseThread;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class BaseCommentTest extends \PHPUnit_Framework_TestCase
+class BaseCommentTest extends TestCase
 {
     public function testGetters()
     {

--- a/Tests/Entity/BaseThreadTest.php
+++ b/Tests/Entity/BaseThreadTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CommentBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CommentBundle\Entity\BaseThread;
 
 /**
@@ -18,7 +19,7 @@ use Sonata\CommentBundle\Entity\BaseThread;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class BaseThreadTest extends \PHPUnit_Framework_TestCase
+class BaseThreadTest extends TestCase
 {
     /**
      * Tests setters & getters.
@@ -56,7 +57,7 @@ class BaseThreadTest extends \PHPUnit_Framework_TestCase
         }
 
         // Given
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->createMock('Sonata\ClassificationBundle\Model\CategoryInterface');
         $category->expects($this->once())->method('getName')->will($this->returnValue('my-category'));
 
         $thread = new BaseThread();

--- a/Tests/Note/NoteProviderTest.php
+++ b/Tests/Note/NoteProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CommentBundle\Tests\Note;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CommentBundle\Note\NoteProvider;
 
 /**
@@ -18,7 +19,7 @@ use Sonata\CommentBundle\Note\NoteProvider;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class NoteProviderTest extends \PHPUnit_Framework_TestCase
+class NoteProviderTest extends TestCase
 {
     /**
      * Test findAverageNote() method.
@@ -26,7 +27,7 @@ class NoteProviderTest extends \PHPUnit_Framework_TestCase
     public function testFindAverageNote()
     {
         // Given
-        $thread = $this->getMock('Sonata\CommentBundle\Model\Thread');
+        $thread = $this->createMock('Sonata\CommentBundle\Model\Thread');
 
         $commentManager = $this->getMockBuilder('Sonata\CommentBundle\Manager\CommentManager')
             ->disableOriginalConstructor()
@@ -48,7 +49,7 @@ class NoteProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetValues()
     {
         // Given
-        $thread = $this->getMock('Sonata\CommentBundle\Model\Thread');
+        $thread = $this->createMock('Sonata\CommentBundle\Model\Thread');
 
         $commentManager = $this->getMockBuilder('Sonata\CommentBundle\Manager\CommentManager')
             ->disableOriginalConstructor()

--- a/Tests/Renderer/CommentStatusRendererTest.php
+++ b/Tests/Renderer/CommentStatusRendererTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CommentBundle\Tests\Renderer;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\CommentBundle\Model\Comment;
 use Sonata\CommentBundle\Renderer\CommentStatusRenderer;
 
@@ -19,7 +20,7 @@ use Sonata\CommentBundle\Renderer\CommentStatusRenderer;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class CommentStatusRendererTest extends \PHPUnit_Framework_TestCase
+class CommentStatusRendererTest extends TestCase
 {
     /**
      * Should handle only Comment model class.
@@ -31,7 +32,7 @@ class CommentStatusRendererTest extends \PHPUnit_Framework_TestCase
         $comment = new \DateTime();
         $this->assertFalse($commentStatusRenderer->handlesObject($comment));
 
-        $comment = $this->getMock('Sonata\CommentBundle\Model\Comment');
+        $comment = $this->createMock('Sonata\CommentBundle\Model\Comment');
         $this->assertTrue($commentStatusRenderer->handlesObject($comment));
 
         foreach (['moderate', 'invalid', 'valid'] as $correctStatusType) {
@@ -48,7 +49,7 @@ class CommentStatusRendererTest extends \PHPUnit_Framework_TestCase
     {
         $commentStatusRenderer = new CommentStatusRenderer();
 
-        $comment = $this->getMock('Sonata\CommentBundle\Model\Comment');
+        $comment = $this->createMock('Sonata\CommentBundle\Model\Comment');
         $comment->expects($this->once())->method('getState')->will($this->returnValue(array_rand(Comment::getStateList())));
 
         $this->assertContains($commentStatusRenderer->getStatusClass($comment, '', 'error'), ['success', 'info', 'important']);
@@ -61,7 +62,7 @@ class CommentStatusRendererTest extends \PHPUnit_Framework_TestCase
     {
         $commentStatusRenderer = new CommentStatusRenderer();
 
-        $comment = $this->getMock('Sonata\CommentBundle\Model\Comment');
+        $comment = $this->createMock('Sonata\CommentBundle\Model\Comment');
         $comment->expects($this->once())->method('getState')->will($this->returnValue(8));
 
         $this->assertEquals('default_value', $commentStatusRenderer->getStatusClass($comment, 'statusName', 'default_value'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Removed compatibility with PHPUnit 4. Fixes: https://github.com/sebastianbergmann/phpunit/issues/2809