### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,11 @@
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
         "symfony/security": "^2.8 || ^3.2 || ^4.0"
     },
+    "conflict": {
+        "sonata-project/block-bundle": "<3.11"
+    },
     "require-dev": {
+        "sonata-project/block-bundle": "^3.11",
         "sonata-project/classification-bundle": "^3.0",
         "sonata-project/media-bundle": "^3.6",
         "symfony/phpunit-bridge": "^3.3 || ^4.0"

--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -54,4 +54,4 @@ Else, you can use this Twig include:
 
 .. code-block:: jinja
 
-    {% include 'SonataCommentBundle:Thread:async.html.twig' with {'id': 'my-custom-thread-identifier'} %}
+    {% include '@SonataComment/Thread/async.html.twig' with {'id': 'my-custom-thread-identifier'} %}

--- a/src/Admin/Model/CommentAdmin.php
+++ b/src/Admin/Model/CommentAdmin.php
@@ -65,7 +65,7 @@ abstract class CommentAdmin extends Admin
             ->add('body', 'text')
             ->add('createdAt', 'datetime')
             ->add('note', 'float')
-            ->add('state', 'string', ['template' => 'SonataCommentBundle:CommentAdmin:list_status.html.twig'])
+            ->add('state', 'string', ['template' => '@SonataComment/CommentAdmin/list_status.html.twig'])
             ->add('private', 'boolean', ['editable' => true])
         ;
     }

--- a/src/Block/CommentThreadAsyncBlockService.php
+++ b/src/Block/CommentThreadAsyncBlockService.php
@@ -34,7 +34,7 @@ class CommentThreadAsyncBlockService extends BaseBlockService
     {
         $resolver->setDefaults([
             'id' => null,
-            'template' => 'SonataCommentBundle:Block:thread_async.html.twig',
+            'template' => '@SonataComment/Block/thread_async.html.twig',
         ]);
     }
 

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -7,7 +7,7 @@
         <service id="sonata.comment.block.thread.async" class="%sonata.comment.block.thread.async.class%">
             <tag name="sonata.block"/>
             <argument>sonata.comment.block.thread.async</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
     </services>
 </container>

--- a/src/Resources/views/Block/thread_async.html.twig
+++ b/src/Resources/views/Block/thread_async.html.twig
@@ -1,1 +1,1 @@
-{% include 'SonataCommentBundle:Thread:async.html.twig' with {'id': settings.id } %}
+{% include '@SonataComment/Thread/async.html.twig' with {'id': settings.id } %}

--- a/src/Resources/views/CommentAdmin/list_status.html.twig
+++ b/src/Resources/views/CommentAdmin/list_status.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field %}
     <span class="label{{ object|sonata_status_class(null, 'danger') ? ' label-'~object|sonata_status_class(null, 'danger') : '' }}">{{ object.stateLabel|trans([], 'SonataCommentBundle') }}</span>

--- a/src/Resources/views/Thread/comment_content.html.twig
+++ b/src/Resources/views/Thread/comment_content.html.twig
@@ -48,7 +48,7 @@
                         <div class="fos_comment_comment_voting">
                             <button data-url="{{ url("fos_comment_new_thread_comment_votes", {"id": comment.thread.id, "commentId": comment.id, "value": 1}) }}" class="btn btn-default fos_comment_comment_vote">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_voteup{% endtrans %}</button>
                             <button data-url="{{ url("fos_comment_new_thread_comment_votes", {"id": comment.thread.id, "commentId": comment.id, "value": -1}) }}" class="btn btn-default fos_comment_comment_vote">{% trans from 'FOSCommentBundle' %}fos_comment_comment_show_votedown{% endtrans %}</button>
-                            <div class="fos_comment_comment_score" id="fos_comment_score_{{ comment.id }}">{% include "FOSCommentBundle:Thread:comment_votes.html.twig" with { 'commentScore': comment.score } %}</div>
+                            <div class="fos_comment_comment_score" id="fos_comment_score_{{ comment.id }}">{% include "@FOSComment/Thread/comment_votes.html.twig" with { 'commentScore': comment.score } %}</div>
                         </div>
                     {% endif %}
                 {% endblock fos_comment_comment_metas_voting %}
@@ -86,12 +86,12 @@
                 <div class="col-sm-offset-1 fos_comment_comment_replies">
 
                     {% if children is defined %}
-                        {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parent": comment, "view": view } %}
+                        {% include "@FOSComment/Thread/comments.html.twig" with { "comments": children, "depth": depth + 1, "parent": comment, "view": view } %}
                     {% endif %}
 
                 </div>
             {% elseif view is sameas('flat') and children is defined %}
-                {% include "FOSCommentBundle:Thread:comments.html.twig" with { "comments": children, "depth": depth + 1, "parent": comment, "view": view } %}
+                {% include "@FOSComment/Thread/comments.html.twig" with { "comments": children, "depth": depth + 1, "parent": comment, "view": view } %}
             {% endif %}
         {% endblock fos_comment_comment_children %}
 

--- a/src/Resources/views/Thread/comments.html.twig
+++ b/src/Resources/views/Thread/comments.html.twig
@@ -31,6 +31,6 @@
 
 {% for commentinfo in comments %}
     {% if not commentinfo.comment.private %}
-        {% include "FOSCommentBundle:Thread:comment.html.twig" with { "children": commentinfo.children, "comment": commentinfo.comment, "depth": depth, "view": view } %}
+        {% include "@FOSComment/Thread/comment.html.twig" with { "children": commentinfo.children, "comment": commentinfo.comment, "depth": depth, "view": view } %}
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details