### PR TITLE
Update installation documentation for Symfony Flex

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -10,18 +10,17 @@ Installation
 Prerequisites
 -------------
 
-PHP 5.3 and Symfony 2 are needed to make this bundle work; there are also some
-Sonata dependencies that need to be installed and configured beforehand:
+PHP 5.6 and Symfony 2.8, >=3.3 or 4 are needed to make this bundle work, there are
+also some Sonata dependencies that need to be installed and configured beforehand:
 
 * `SonataAdminBundle <https://sonata-project.org/bundles/admin>`_
 * `SonataEasyExtendsBundle <https://sonata-project.org/bundles/easy-extends>`_
 
-You will need to install those in their 2.0 branches (or master if they don't
-have a similar branch). Follow also their configuration step; you will find
-everything you need in their installation chapter.
+You will need to install those in their 2.0 or 3.0 branches. Follow also
+their configuration step; you will find everything you need in their own
+installation chapter.
 
 .. note::
-
     If a dependency is already installed somewhere in your project or in
     another dependency, you won't need to install it again.
 
@@ -32,12 +31,30 @@ Use these commands:
 
 .. code-block:: bash
 
-    php composer require sonata-project/comment-bundle --no-update
-    php composer require sonata-project/doctrine-orm-admin-bundle --no-update # optional
-    php composer update
+    composer require sonata-project/comment-bundle --no-update
+    composer require sonata-project/doctrine-orm-admin-bundle --no-update # optional
+    composer update
 
-Next, be sure to enable the bundles in your autoload.php and AppKernel.php
-files:
+Next, be sure to enable the bundles in your ``bundles.php`` file if they
+are not already enabled:
+
+.. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        FOS\CommentBundle\FOSCommentBundle::class => ['all' => true],
+        Sonata\CoreBundle\SonataCoreBundle::class => ['all' => true],
+        Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
+        Sonata\CommentBundle\SonataCommentBundle::class => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, you should enable bundles in your
+    ``AppKernel.php``.
 
 .. code-block:: php
 
@@ -56,44 +73,58 @@ files:
         );
     }
 
-.. note::
-
-    If you already have installed a Sonata dependency, you may ignore the step
-    on the modification of the ``autoload.php`` file.
-
 Configuration
 -------------
-Here is the configuration you will need to add:
+
+.. note::
+    If you are not using Symfony Flex, all configuration in this section should
+    be added to ``app/config/config.yml``.
+
+SonataCommentBundle Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
-    # app/config/config.yml
+    # config/packages/sonata.yaml
 
     sonata_comment:
         manager_type: orm # can be 'orm' or 'mongodb'
         class:
-            comment: Application\Sonata\CommentBundle\Entity\Comment # This is an optional value
-            thread: Application\Sonata\CommentBundle\Entity\Thread   # This is an optional value
+            comment: App\Application\Sonata\CommentBundle\Entity\Comment # This is an optional value
+            thread: App\Application\Sonata\CommentBundle\Entity\Thread   # This is an optional value
 
-Doctrine Configuration
-~~~~~~~~~~~~~~~~~~~~~~
-Then, add these bundles in the config mapping definition (or enable `auto_mapping <http://symfony.com/doc/2.0/reference/configuration/doctrine.html#configuration-overview>`_):
+.. note::
+    If you are not using Symfony Flex, add classes without the ``App\``
+    part.
+
+FOSCommentBundle Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
-    # app/config/config.yml
+    # config/packages/fos_comment.yaml
 
     fos_comment:
         db_driver: orm
         class:
             model:
-                comment: Application\Sonata\CommentBundle\Entity\Comment
-                thread: Application\Sonata\CommentBundle\Entity\Thread
+                comment: App\Application\Sonata\CommentBundle\Entity\Comment
+                thread: App\Application\Sonata\CommentBundle\Entity\Thread
         form:
             comment:
                 type: sonata_comment_comment
-        notes:
-            values: [1, 2, 3] # Optional, default would be: [1, 2, 3, 4, 5]
+
+.. note::
+    If you are not using Symfony Flex, add classes without the ``App\``
+    part.
+
+Doctrine Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+Add these bundles in the config mapping definition (or enable `auto_mapping <http://symfony.com/doc/2.0/reference/configuration/doctrine.html#configuration-overview>`_):
+
+.. code-block:: yaml
+
+    # config/packages/doctrine.yaml
 
     doctrine:
         orm:
@@ -114,19 +145,40 @@ generate the correct entities for the media:
 
 .. code-block:: bash
 
-    php app/console sonata:easy-extends:generate SonataCommentBundle
+    bin/console sonata:easy-extends:generate SonataCommentBundle --dest=src --namespace_prefix=App
 
-If you specify no parameter, the files are generated in app/Application/Sonata... but you can specify the path with `--dest=src`.
+.. note::
+    If you are not using Symfony Flex, use command without ``--namespace_prefix=App``.
+
+With provided parameters, the files are generated in ``src/Application/Sonata/CommentBundle``.
 
 .. note::
 
-    The command will generate domain objects in an ``Application`` namespace.
+    The command will generate domain objects in an ``App\Application`` namespace.
     So you can point entities' associations to a global and common namespace.
     This will make Entities sharing easier as your models will allow to
     point to a global namespace. For instance the user will be
-    ``Application\Sonata\CommentBundle\Entity\Thread``.
+    ``App\Application\Sonata\CommentBundle\Entity\Thread``.
 
-Now, add the new `Application` Bundle into the kernel:
+.. note::
+    If you are not using Symfony Flex, the namespace will be ``Application\Sonata\CommentBundle\Entity``.
+
+Now, add the new ``Application`` Bundle into the ``bundles.php``:
+
+.. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        App\Application\Sonata\CommentBundle\ApplicationSonataCommentBundle::class => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, add the new ``Application`` Bundle into your
+    ``AppKernel.php``.
 
 .. code-block:: php
 
@@ -146,3 +198,9 @@ Now, add the new `Application` Bundle into the kernel:
             )
         }
     }
+
+The only thing left is to update your schema:
+
+.. code-block:: bash
+
+    php bin/console doctrine:schema:update --force


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am updating documentation for Symfony Flex.

## Subject

Updating documentation to adopt new flex structure.