### PR TITLE
Minor composer improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "friendsofsymfony/comment-bundle": "^2.0.13",
-        "sonata-project/core-bundle": "^3.0",
+        "sonata-project/core-bundle": "^3.9",
         "sonata-project/doctrine-extensions": "^1.0",
-        "sonata-project/easy-extends-bundle": "^2.1",
+        "sonata-project/easy-extends-bundle": "^2.4",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/event-dispatcher": "^2.8 || ^3.2 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,22 @@
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.1",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
+        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
+        "symfony/event-dispatcher": "^2.8 || ^3.2 || ^4.0",
         "symfony/form": "^2.8 || ^3.2 || ^4.0",
+        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
-        "symfony/security": "^2.8 || ^3.2 || ^4.0"
+        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
+        "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0"
     },
     "conflict": {
         "sonata-project/block-bundle": "<3.11"
     },
     "require-dev": {
+        "sonata-project/admin-bundle": "^3.31",
         "sonata-project/block-bundle": "^3.11",
-        "sonata-project/classification-bundle": "^3.0",
-        "sonata-project/media-bundle": "^3.6",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0"
+        "sonata-project/classification-bundle": "^3.6",
+        "symfony/phpunit-bridge": "^4.0"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "For doctrine ORM admin integration"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
- Declared missing composer dependencies
- Removed media-bundle (unused here): It was added here: https://github.com/sonata-project/SonataCommentBundle/pull/17, but there is no reason for media-bundle, just classification is needed
- Add admin-bundle (used many times, but as a dev-dependency, because of this: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/src/DependencyInjection/SonataCommentExtension.php#L51
- Up phpunit-bridge to 4.0
- Up some other sonata packages to avoid long prefer-lowest builds
- Removed symfony/security: 

It was added here: https://github.com/sonata-project/SonataCommentBundle/commit/072c69cf1fc3c266d640cdb5e24aceede7a2d097#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R23 
then 3 days after it was removed its only usage: https://github.com/sonata-project/SonataCommentBundle/commit/539fd034c3037d4cc7adb19a7cf49ef5d1063638#diff-ba1eb6bc98752a61be527ca1e3ef4c0bL46
and `use` was removed here: https://github.com/sonata-project/SonataCommentBundle/commit/089e66d36c85786900a2bac6fd22d7118260ad3d#diff-ba1eb6bc98752a61be527ca1e3ef4c0bL14