### PR TITLE
Dropping support for symfony < 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,14 @@
         "sonata-project/core-bundle": "^3.9",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.4",
-        "symfony/console": "^2.8 || ^3.2 || ^4.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
-        "symfony/event-dispatcher": "^2.8 || ^3.2 || ^4.0",
-        "symfony/form": "^2.8 || ^3.2 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
-        "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0"
+        "symfony/console": "^3.4 || ^4.2",
+        "symfony/dependency-injection": "^3.4 || ^4.2",
+        "symfony/event-dispatcher": "^3.4 || ^4.2",
+        "symfony/form": "^3.4 || ^4.2",
+        "symfony/framework-bundle": "^3.4 || ^4.2",
+        "symfony/http-foundation": "^3.4 || ^4.2",
+        "symfony/http-kernel": "^3.4 || ^4.2",
+        "symfony/options-resolver": "^3.4 || ^4.2"
     },
     "conflict": {
         "sonata-project/block-bundle": "<3.11"

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -10,7 +10,7 @@ Installation
 Prerequisites
 -------------
 
-PHP 5.6 and Symfony 2.8, >=3.3 or 4 are needed to make this bundle work, there are
+PHP 7.1 and Symfony >=3.4 or >= 4.2 are needed to make this bundle work, there are
 also some Sonata dependencies that need to be installed and configured beforehand:
 
 * `SonataAdminBundle <https://sonata-project.org/bundles/admin>`_

--- a/src/Form/Type/CommentType.php
+++ b/src/Form/Type/CommentType.php
@@ -73,7 +73,9 @@ class CommentType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/comment-bundle 3.x, to be removed in version 4.0.
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
@@ -102,7 +104,9 @@ class CommentType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/comment-bundle 3.x, to be removed in version 4.0.
      */
     public function getName()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This is the same thing as https://github.com/sonata-project/SonataAdminBundle/pull/5733, dropping support of Symfony < 3.4 and >= 4, < 4.2
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for Symfony < 3.4
- Support for Symfony >= 4, < 4.2
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->