### PR TITLE
Make CoreBundle optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,10 @@
     "require": {
         "php": "^7.1",
         "friendsofsymfony/comment-bundle": "^2.0.13",
-        "sonata-project/core-bundle": "^3.18",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.4",
+        "sonata-project/form-extensions": "^0.1 || ^1.4",
+        "sonata-project/twig-extensions": "^0.1 || ^1.3",
         "symfony/console": "^3.4 || ^4.2",
         "symfony/dependency-injection": "^3.4 || ^4.2",
         "symfony/event-dispatcher": "^3.4 || ^4.2",

--- a/src/Admin/Model/CommentAdmin.php
+++ b/src/Admin/Model/CommentAdmin.php
@@ -18,7 +18,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\CommentBundle\Form\Type\CommentStatusType;
-use Sonata\CoreBundle\Form\Type\DateTimePickerType;
+use Sonata\Form\Type\DateTimePickerType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 abstract class CommentAdmin extends Admin

--- a/src/Block/CommentThreadAsyncBlockService.php
+++ b/src/Block/CommentThreadAsyncBlockService.php
@@ -17,7 +17,7 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Sonata\Form\Type\ImmutableArrayType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/src/Form/Type/CommentStatusType.php
+++ b/src/Form/Type/CommentStatusType.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\CommentBundle\Form\Type;
 
-use Sonata\CoreBundle\Form\Type\StatusType;
+use Sonata\Form\Type\StatusType;
 
 class CommentStatusType extends StatusType
 {

--- a/src/Renderer/CommentStatusRenderer.php
+++ b/src/Renderer/CommentStatusRenderer.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\CommentBundle\Renderer;
 
 use Sonata\CommentBundle\Model\Comment;
-use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
+use Sonata\Twig\Status\StatusClassRendererInterface;
 
 /**
  * Class CommentStatusRenderer.

--- a/src/SonataCommentBundle.php
+++ b/src/SonataCommentBundle.php
@@ -25,24 +25,18 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class SonataCommentBundle extends Bundle
 {
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getParent()
     {
         return 'FOSCommentBundle';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function build(ContainerBuilder $container)
     {
         $this->registerFormMapping();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function boot()
     {
         $this->registerFormMapping();
@@ -50,17 +44,21 @@ class SonataCommentBundle extends Bundle
 
     /**
      * Register form mapping information.
+     *
+     * NEXT_MAJOR: remove this method
      */
     public function registerFormMapping()
     {
-        FormHelper::registerFormTypeMapping([
-            'fos_comment_comment' => 'FOS\CommentBundle\Form\CommentType',
-            'fos_comment_commentable_thread' => 'FOS\CommentBundle\Form\CommentableThreadType',
-            'fos_comment_delete_comment' => 'FOS\CommentBundle\Form\DeleteCommentType',
-            'fos_comment_thread' => 'FOS\CommentBundle\Form\ThreadType',
-            'fos_comment_vote' => 'FOS\CommentBundle\Form\VoteType',
-            'sonata_comment_comment' => 'Sonata\CommentBundle\Form\Type\CommentType',
-            'sonata_comment_status' => 'Sonata\CommentBundle\Form\Type\CommentStatusType',
-        ]);
+        if (class_exists(FormHelper::class)) {
+            FormHelper::registerFormTypeMapping([
+                'fos_comment_comment' => 'FOS\CommentBundle\Form\CommentType',
+                'fos_comment_commentable_thread' => 'FOS\CommentBundle\Form\CommentableThreadType',
+                'fos_comment_delete_comment' => 'FOS\CommentBundle\Form\DeleteCommentType',
+                'fos_comment_thread' => 'FOS\CommentBundle\Form\ThreadType',
+                'fos_comment_vote' => 'FOS\CommentBundle\Form\VoteType',
+                'sonata_comment_comment' => 'Sonata\CommentBundle\Form\Type\CommentType',
+                'sonata_comment_status' => 'Sonata\CommentBundle\Form\Type\CommentStatusType',
+            ]);
+        }
     }
 }

--- a/tests/Resources/XliffTest.php
+++ b/tests/Resources/XliffTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\CommentBundle\Tests\Resources;
 
-use Sonata\CoreBundle\Test\XliffValidatorTestCase;
-
 /**
  * This is a XliffTest class to ensure that translations are correctly formatted.
  */

--- a/tests/Resources/XliffValidatorTestCase.php
+++ b/tests/Resources/XliffValidatorTestCase.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CommentBundle\Tests\Resources;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Exception\InvalidResourceException;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+
+abstract class XliffValidatorTestCase extends TestCase
+{
+    /**
+     * @var XliffFileLoader
+     */
+    protected $loader;
+
+    /**
+     * @var string[]
+     */
+    protected $errors = [];
+
+    protected function setUp(): void
+    {
+        $this->loader = new XliffFileLoader();
+    }
+
+    /**
+     * @dataProvider getXliffPaths
+     */
+    public function testXliff($path)
+    {
+        $this->validatePath($path);
+
+        if (\count($this->errors) > 0) {
+            $this->fail(sprintf('Unable to parse xliff files: %s', implode(', ', $this->errors)));
+        }
+
+        $this->assertCount(
+            0,
+            $this->errors,
+            sprintf('Unable to parse xliff files: %s', implode(', ', $this->errors))
+        );
+    }
+
+    /**
+     * @return array List all path to validate xliff
+     */
+    abstract public function getXliffPaths();
+
+    /**
+     * @param string $file The path to the xliff file
+     */
+    protected function validateXliff($file)
+    {
+        try {
+            $this->loader->load($file, 'en');
+            $this->assertTrue(true, sprintf('Successful loading file: %s', $file));
+        } catch (InvalidResourceException $e) {
+            $this->errors[] = sprintf('%s => %s', $file, $e->getMessage());
+        }
+    }
+
+    /**
+     * @param string $path The path to lookup for Xliff file
+     */
+    protected function validatePath($path)
+    {
+        $files = glob(sprintf('%s/*.xliff', $path));
+
+        foreach ($files as $file) {
+            $this->validateXliff($file);
+        }
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of https://github.com/sonata-project/dev-kit/issues/697

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCommentBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- remove SonataCoreBundle dependencies
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
