### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "symfony/options-resolver": "^3.4 || ^4.2"
     },
     "conflict": {
-        "sonata-project/block-bundle": "<3.11"
+        "sonata-project/block-bundle": "<3.11",
+        "sonata-project/core-bundle": "<3.20"
     },
     "require-dev": {
         "sonata-project/admin-bundle": "^3.58",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This change will allow install optionally only CoreBundle v3.20 (which constains all deprecations notes).

#### Remove process will be look like:
- update CoreBundle to 3.20
- remove deprecations
- remove CoreBundle
- upgrade extensions to 1.x

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because this change respect BC.

