### PR TITLE
Make SonataEasyExtends optional

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,11 +1,19 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### SonataEasyExtends is deprecated
+
+Registering `SonataEasyExtendsBundle` bundle is deprecated, it SHOULD NOT be registered.
+Register `SonataDoctrineBundle` bundle instead.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -20,30 +20,31 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "friendsofsymfony/comment-bundle": "^2.0.13",
-        "sonata-project/doctrine-extensions": "^1.0",
-        "sonata-project/easy-extends-bundle": "^2.4",
+        "php": "^7.2",
+        "friendsofsymfony/comment-bundle": "^2.4",
+        "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "sonata-project/twig-extensions": "^0.1 || ^1.3",
-        "symfony/console": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/event-dispatcher": "^3.4 || ^4.2",
-        "symfony/form": "^3.4 || ^4.2",
-        "symfony/framework-bundle": "^3.4 || ^4.2",
-        "symfony/http-foundation": "^3.4 || ^4.2",
-        "symfony/http-kernel": "^3.4 || ^4.2",
-        "symfony/options-resolver": "^3.4 || ^4.2"
+        "symfony/console": "^4.4",
+        "symfony/dependency-injection": "^4.4",
+        "symfony/event-dispatcher": "^4.4",
+        "symfony/form": "^4.4",
+        "symfony/framework-bundle": "^4.4",
+        "symfony/http-foundation": "^4.4",
+        "symfony/http-kernel": "^4.4",
+        "symfony/options-resolver": "^4.4"
     },
     "conflict": {
-        "sonata-project/block-bundle": "<3.11",
+        "sonata-project/block-bundle": "<3.18",
         "sonata-project/core-bundle": "<3.20"
     },
     "require-dev": {
+        "matthiasnoback/symfony-config-test": "^4.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "sonata-project/admin-bundle": "^3.58",
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/classification-bundle": "^3.9",
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/phpunit-bridge": "^5.1"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "For doctrine ORM admin integration"

--- a/docs/reference/introduction.rst
+++ b/docs/reference/introduction.rst
@@ -11,4 +11,3 @@ Integrates the comments with the different Sonata bundles. It uses
 The following Sonata bundles are marked as a dependency:
 
 * SonataAdminBundle: add user and group management
-* SonataEasyExtendsBundle: allows to generate Application level model

--- a/src/DependencyInjection/SonataCommentExtension.php
+++ b/src/DependencyInjection/SonataCommentExtension.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\CommentBundle\DependencyInjection;
 
-use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
+use FOS\CommentBundle\Model\SignedCommentInterface;
+use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
+use Sonata\Doctrine\Mapper\DoctrineCollector;
+use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector as DeprecatedDoctrineCollector;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -63,7 +66,12 @@ class SonataCommentExtension extends Extension
 
         $config = $this->addDefaults($config, $modelType);
 
-        $this->registerDoctrineMapping($config, $container);
+        if ($this->hasBundle('SonataDoctrineBundle', $container)) {
+            $this->registerSonataDoctrineMapping($config, $container, $modelType);
+        } else {
+            // NEXT MAJOR: Remove next line and throw error when not registering SonataDoctrineBundle
+            $this->registerDoctrineMapping($config, $container);
+        }
 
         $this->configureAdminClass($config, $container);
         $this->configureClass($config, $container, $modelType);
@@ -79,7 +87,8 @@ class SonataCommentExtension extends Extension
             $commentClass = $container->getParameter(sprintf('sonata.comment.class.comment.%s', $modelType));
             $isSignedInterface = is_subclass_of($commentClass, 'FOS\CommentBundle\Model\SignedCommentInterface');
 
-            if ($isSignedInterface) {
+            // NEXT MAJOR: Remove this if, it is registering all mapping on `registerSonataDoctrineMapping`
+            if ($isSignedInterface && !$this->hasBundle('SonataDoctrineBundle', $container)) {
                 $this->registerSonataUserDoctrineMapping($config, $container, $modelType);
             }
         }
@@ -174,18 +183,25 @@ class SonataCommentExtension extends Extension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param array            $config    A configuration array
      * @param ContainerBuilder $container Symfony container builder
      */
     public function registerDoctrineMapping(array $config, ContainerBuilder $container)
     {
+        @trigger_error(
+            'Using SonataEasyExtendsBundle is deprecated since sonata-project/comment-bundle 3.x. Please register SonataDoctrineBundle as a bundle instead.',
+            E_USER_DEPRECATED
+        );
+
         foreach ($config['class'] as $class) {
             if (!class_exists($class)) {
                 return;
             }
         }
 
-        $collector = DoctrineCollector::getInstance();
+        $collector = DeprecatedDoctrineCollector::getInstance();
 
         // Comment.
 
@@ -219,19 +235,26 @@ class SonataCommentExtension extends Extension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param array            $config    A configuration array
      * @param ContainerBuilder $container Symfony container builder
      * @param string           $modelType Configuration model type
      */
     public function registerSonataUserDoctrineMapping(array $config, ContainerBuilder $container, $modelType)
     {
+        @trigger_error(
+            'Using SonataEasyExtendsBundle is deprecated since sonata-project/comment-bundle 3.x. Please register SonataDoctrineBundle as a bundle instead.',
+            E_USER_DEPRECATED
+        );
+
         foreach ($config['class'] as $class) {
             if (!class_exists($class)) {
                 return;
             }
         }
 
-        $collector = DoctrineCollector::getInstance();
+        $collector = DeprecatedDoctrineCollector::getInstance();
 
         $userClass = $container->getParameter(sprintf('sonata.user.admin.user.%s', $modelType));
 
@@ -255,5 +278,51 @@ class SonataCommentExtension extends Extension
         $bundles = $container->getParameter('kernel.bundles');
 
         return isset($bundles[$name]);
+    }
+
+    private function registerSonataDoctrineMapping(array $config, ContainerBuilder $container, string $modelType): void
+    {
+        foreach ($config['class'] as $class) {
+            if (!class_exists($class)) {
+                return;
+            }
+        }
+
+        $collector = DoctrineCollector::getInstance();
+
+        $collector->addAssociation(
+            $config['class']['comment'],
+            'mapManyToOne',
+            OptionsBuilder::createManyToOne('thread', $config['class']['thread'])
+        );
+
+        if ($this->hasBundle('SonataClassificationBundle', $container)) {
+            $collector->addAssociation(
+                $config['class']['comment'],
+                'mapManyToOne',
+                OptionsBuilder::createManyToOne('category', $config['class']['category'])
+                    ->cascade(['persist'])
+                    ->addJoin([
+                        'name' => 'category_id',
+                        'referencedColumnName' => 'id',
+                        'onDelete' => 'CASCADE',
+                        'onUpdate' => 'CASCADE',
+                    ])
+            );
+        }
+
+        if ($this->hasBundle('SonataUserBundle', $container)) {
+            $commentClass = $container->getParameter(sprintf('sonata.comment.class.comment.%s', $modelType));
+
+            if (is_subclass_of($commentClass, SignedCommentInterface::class)) {
+                $userClass = $container->getParameter(sprintf('sonata.user.admin.user.%s', $modelType));
+
+                $collector->addAssociation(
+                    $config['class']['comment'],
+                    'mapManyToOne',
+                    OptionsBuilder::createManyToOne('author', $userClass)
+                );
+            }
+        }
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CommentBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
+use Sonata\CommentBundle\DependencyInjection\Configuration;
+use Sonata\CommentBundle\DependencyInjection\SonataCommentExtension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+final class ConfigurationTest extends AbstractExtensionConfigurationTestCase
+{
+    public function testDefault(): void
+    {
+        $this->assertProcessedConfigurationEquals([
+            'provider' => 'fos_comment',
+            'manager_type' => 'orm',
+            'notes' => [
+                'values' => [1, 2, 3, 4, 5],
+            ],
+            'admin' => [
+                'comment' => [
+                    'controller' => 'SonataAdminBundle:CRUD',
+                    'translation' => 'SonataCommentBundle',
+                ],
+                'thread' => [
+                    'controller' => 'SonataAdminBundle:CRUD',
+                    'translation' => 'SonataCommentBundle',
+                ],
+            ],
+        ], [
+            __DIR__.'/../Fixtures/configuration.yaml',
+        ]);
+    }
+
+    protected function getContainerExtension(): ExtensionInterface
+    {
+        return new SonataCommentExtension();
+    }
+
+    protected function getConfiguration(): ConfigurationInterface
+    {
+        return new Configuration();
+    }
+}

--- a/tests/DependencyInjection/SonataCommentExtensionTest.php
+++ b/tests/DependencyInjection/SonataCommentExtensionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CommentBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\CommentBundle\Admin\Entity\CommentAdmin;
+use Sonata\CommentBundle\Admin\Entity\ThreadAdmin;
+use Sonata\CommentBundle\Block\CommentThreadAsyncBlockService;
+use Sonata\CommentBundle\Command\SynchronizeCommand;
+use Sonata\CommentBundle\DependencyInjection\SonataCommentExtension;
+use Sonata\CommentBundle\Event\CommentThreadAsyncListener;
+use Sonata\CommentBundle\Form\Type\CommentStatusType;
+use Sonata\CommentBundle\Form\Type\CommentType;
+use Sonata\CommentBundle\Manager\CommentManager;
+use Sonata\CommentBundle\Manager\ThreadManager;
+use Sonata\CommentBundle\Note\NoteProvider;
+
+final class SonataCommentExtensionTest extends AbstractExtensionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container->setParameter('kernel.bundles', [
+            'SonataDoctrineBundle' => true,
+            'SonataAdminBundle' => true,
+            'SonataBlockBundle' => true,
+            'SonataUserBundle' => true,
+        ]);
+    }
+
+    public function testLoadDefault(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasService('sonata.comment.admin.comment', CommentAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.comment.admin.thread', ThreadAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.comment.block.thread.async', CommentThreadAsyncBlockService::class);
+        $this->assertContainerBuilderHasService(SynchronizeCommand::class);
+        $this->assertContainerBuilderHasService('sonata.comment.event.sonata.comment', CommentThreadAsyncListener::class);
+        $this->assertContainerBuilderHasService('sonata.comment.form.comment_type', CommentType::class);
+        $this->assertContainerBuilderHasService('sonata.comment.form.comment_status_type', CommentStatusType::class);
+        $this->assertContainerBuilderHasService('sonata.comment.note.provider', NoteProvider::class);
+        $this->assertContainerBuilderHasService('sonata.comment.manager.comment', CommentManager::class);
+        $this->assertContainerBuilderHasService('sonata.comment.manager.thread', ThreadManager::class);
+
+        $this->assertContainerBuilderHasParameter('sonata.comment.admin.groupname', 'sonata_comment');
+        $this->assertContainerBuilderHasParameter('sonata.comment.block.thread.async.class', CommentThreadAsyncBlockService::class);
+        $this->assertContainerBuilderHasParameter('sonata.comment.manager.comment.class', CommentManager::class);
+        $this->assertContainerBuilderHasParameter('sonata.comment.manager.thread.class', ThreadManager::class);
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new SonataCommentExtension(),
+        ];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

Part of: https://github.com/sonata-project/dev-kit/issues/750

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

SonataEasyExtends is deprecated but it is used on many bundles, this makes it optional. This change is BC because if the user does not change anything it will continue using the deprecated code but with a message.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- SonataEasyExtendsBundle is now optional, using SonataDoctrineBundle is preferred
### Deprecated
- Using SonataEasyExtendsBundle to add Doctrine mapping information
### Removed
- Support for Symfony < 4.4
```

## To do

- [x] Update the documentation;
- [x] Add an upgrade note.
