### PR TITLE
Fix missing params

### DIFF
--- a/src/DependencyInjection/SonataCommentExtension.php
+++ b/src/DependencyInjection/SonataCommentExtension.php
@@ -42,6 +42,18 @@ class SonataCommentExtension extends Extension
         $configuration = new Configuration();
         $config = $processor->processConfiguration($configuration, $configs);
 
+        if ('orm' === $config['manager_type']) {
+            $modelType = 'entity';
+        } elseif ('mongodb' === $config['manager_type']) {
+            $modelType = 'document';
+        }
+
+        $config = $this->addDefaults($config, $modelType);
+        $this->configureAdminClass($config, $container);
+        $this->configureClass($config, $container, $modelType);
+        $this->configureController($config, $container);
+        $this->configureTranslationDomain($config, $container);
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('event.xml');
         $loader->load('form.xml');
@@ -58,12 +70,6 @@ class SonataCommentExtension extends Extension
             $loader->load(sprintf('admin_%s.xml', $config['manager_type']));
         }
 
-        if ('orm' === $config['manager_type']) {
-            $modelType = 'entity';
-        } elseif ('mongodb' === $config['manager_type']) {
-            $modelType = 'document';
-        }
-
         $config = $this->addDefaults($config, $modelType);
 
         if ($this->hasBundle('SonataDoctrineBundle', $container)) {
@@ -73,10 +79,6 @@ class SonataCommentExtension extends Extension
             $this->registerDoctrineMapping($config, $container);
         }
 
-        $this->configureAdminClass($config, $container);
-        $this->configureClass($config, $container, $modelType);
-        $this->configureController($config, $container);
-        $this->configureTranslationDomain($config, $container);
         $this->configureBlocksEvents($container);
         $this->configureFormTypes($config, $container);
         $this->configureNotesValues($config, $container);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Fix for missing parameters like:
```
You have requested a non-existent parameter "sonata.comment.class.comment.e  
!!    ntity". Did you mean this: "sonata.news.admin.comment.entity"?  
```
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCommentBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- fixed missing "sonata.comment.*" parameters
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
